### PR TITLE
Fix Xcode 6.2 compile error

### DIFF
--- a/Flipbook WatchKit Extension/InterfaceController.swift
+++ b/Flipbook WatchKit Extension/InterfaceController.swift
@@ -15,9 +15,8 @@ class InterfaceController: WKInterfaceController {
     @IBOutlet weak var arcImage: WKInterfaceImage!
     @IBOutlet weak var activityImage: WKInterfaceImage!
     
-    override init(context: AnyObject?) {
-        // Initialize variables here.
-        super.init(context: context)
+    override func awakeWithContext(context: AnyObject?) {
+        super.awakeWithContext(context)
         
         // Configure interface objects here.
         NSLog("%@ init", self)


### PR DESCRIPTION
Similar to #5, but use the new default method instead of deleting it.