### PR TITLE
Fixes compilation, and adds ability to capture animations of overlapping views.

### DIFF
--- a/Flipbook WatchKit Extension/InterfaceController.swift
+++ b/Flipbook WatchKit Extension/InterfaceController.swift
@@ -14,14 +14,6 @@ class InterfaceController: WKInterfaceController {
 
     @IBOutlet weak var arcImage: WKInterfaceImage!
     @IBOutlet weak var activityImage: WKInterfaceImage!
-    
-    override init(context: AnyObject?) {
-        // Initialize variables here.
-        super.init(context: context)
-        
-        // Configure interface objects here.
-        NSLog("%@ init", self)
-    }
 
     override func willActivate() {
         // This method is called when watch view controller is about to be visible to user

--- a/Flipbook.swift
+++ b/Flipbook.swift
@@ -28,6 +28,7 @@ class Flipbook: NSObject {
         self.duration = duration
         self.imagePrefix = imagePrefix
         self.frameInSuperview = frameInSuperview
+        
         imageCounter = 0
         displayLink.frameInterval = frameInterval
         displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)


### PR DESCRIPTION
Example use case:

Using this technique, I was able to capture images for two auxiliary views which while not animating themselves, were overlapped by an animations from another view and so would need to animate on the Watch to keep the animations seamless.

I did this by containing all target views for rendering in a clear superview, and ran multiple flipbooks simultaneously. In my case I was transitioning images, so I used UIViewContentModeCenter, with clip subviews disabled. 

Example: You need to animate view A, which overlaps view B and C. You can now create three flipbooks simultaneously by passing in "frameInSuperview:true" and then on the watch play all three produced animations simultaneously for a seamless animation.