### PR TITLE
Add output messages to the updateBlock implementation of renderTargetView

### DIFF
--- a/Flipbook.swift
+++ b/Flipbook.swift
@@ -64,7 +64,7 @@ class Flipbook: NSObject {
     
     private func newImagePath() -> String? {
         if let documentsDirectory = documentsDirectory() {
-            let imagePath = documentsDirectory.stringByAppendingPathComponent(NSString(format: "%@-%d@2x.png", imagePrefix, imageCounter++))
+            let imagePath = documentsDirectory.stringByAppendingPathComponent(String(format: "%@-%d@2x.png", imagePrefix, imageCounter++))
             return imagePath
         }
         

--- a/Flipbook.swift
+++ b/Flipbook.swift
@@ -37,10 +37,13 @@ class Flipbook: NSObject {
     func renderTargetView(view: UIView, imagePrefix: String, frameCount: Int, updateBlock: (view: UIView, frame: Int) -> Void) {
         self.imagePrefix = imagePrefix
         
+        println("[Flipbook] Starting capture...")
         for frame in 0..<frameCount {
             updateBlock(view: view, frame: frame)
             renderViewToImage(view)
         }
+        println("[Flipbook] Images exported to: \(documentsDirectory()!)")
+        println("[Flipbook] Capture complete!")
     }
     
     func displayLinkTick(sender: CADisplayLink) {


### PR DESCRIPTION
Messages are emitted in the non-block based version of `renderTargetView` when capture begins and ends, and more importantly to inform the user of the location to which the images have been saved. This does not happen in the block-based version of the method however.

This pull request just adds the same `println` statements to the block-based implementation of the method.

Also includes a fix so that Flipbook.swift is valid in the latest version of Swift.